### PR TITLE
Simplify the `chunked_body` function

### DIFF
--- a/blobnet/src/provider.rs
+++ b/blobnet/src/provider.rs
@@ -28,7 +28,7 @@ use tokio_stream::StreamExt;
 use tokio_util::io::StreamReader;
 
 use crate::client::FileClient;
-use crate::utils::{atomic_copy, chunked_body, hash_path};
+use crate::utils::{atomic_copy, hash_path, stream_body};
 use crate::{read_to_vec, Error, ReadStream};
 
 /// Specifies a storage backend for the blobnet service.
@@ -279,7 +279,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> Provider for Remote<C> {
     async fn put(&self, data: ReadStream) -> Result<String, Error> {
         let (_, file) = make_data_tempfile(data).await?;
         self.client
-            .put(|| async { Ok(chunked_body(file.try_clone().await?)) })
+            .put(|| async { Ok(stream_body(Box::pin(file.try_clone().await?))) })
             .await
     }
 }

--- a/blobnet/src/server.rs
+++ b/blobnet/src/server.rs
@@ -13,7 +13,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::headers::{HEADER_FILE_LENGTH, HEADER_RANGE, HEADER_SECRET};
 use crate::provider::Provider;
-use crate::utils::{body_stream, chunked_body, get_hash};
+use crate::utils::{body_stream, get_hash, stream_body};
 
 /// Configuration for the file server.
 pub struct Config {
@@ -94,7 +94,7 @@ async fn handle(config: Arc<Config>, req: Request<Body>) -> Result<Response<Body
             let range = req.headers().get(HEADER_RANGE).and_then(parse_range_header);
             let hash = get_hash(path)?;
             let reader = config.provider.get(hash, range).await?;
-            Ok(Response::new(chunked_body(reader)))
+            Ok(Response::new(stream_body(reader)))
         }
         (&Method::PUT, "/") => {
             let body = req.into_body();


### PR DESCRIPTION
This removes a channel from the critical path and hopefully allows backpressure to be clearer.