### PR TITLE
Make caching provider not require file length

### DIFF
--- a/blobnet/src/lib.rs
+++ b/blobnet/src/lib.rs
@@ -48,6 +48,10 @@ pub enum Error {
     NotFound,
 
     /// The requested range was not satisfiable.
+    ///
+    /// This occurs if the start is greater than the end of the range, or if the
+    /// start is past the file's length. It's okay for the end of the range to
+    /// be past the end of the file; the output will be truncated.
     #[error("range not satisfiable")]
     BadRange,
 


### PR DESCRIPTION
This is important because blobnet would require a second network round trip to check the file length, which isn't good for workloads like blobnet where we shouldn't have range issues regardless because we store it in the image manifest.

To do this, the blobnet API is slightly modified so that ranges dangling past the end of the file are now valid and truncated automatically. This is consistent with S3's API. I also corrected for some of the error handling logic.

I intend to release 0.2 after merging this and then testing the S3 provider locally.