### PR TITLE
Display error messages in HTTP response body

### DIFF
--- a/blobnet/src/lib.rs
+++ b/blobnet/src/lib.rs
@@ -12,7 +12,7 @@
 use std::io;
 use std::pin::Pin;
 
-use hyper::StatusCode;
+use hyper::{Body, Response, StatusCode};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
@@ -73,13 +73,21 @@ impl From<Error> for io::Error {
     }
 }
 
-impl From<Error> for StatusCode {
+impl From<Error> for Response<Body> {
     fn from(err: Error) -> Self {
         match err {
-            Error::NotFound => StatusCode::NOT_FOUND,
-            Error::BadRange => StatusCode::RANGE_NOT_SATISFIABLE,
-            Error::IO(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            Error::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::NotFound => make_resp(StatusCode::NOT_FOUND, err.to_string()),
+            Error::BadRange => make_resp(StatusCode::RANGE_NOT_SATISFIABLE, err.to_string()),
+            Error::IO(_) => make_resp(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
+            Error::Internal(_) => make_resp(StatusCode::INTERNAL_SERVER_ERROR, err.to_string()),
         }
     }
+}
+
+/// Helper function for making a simple text response.
+fn make_resp(code: StatusCode, msg: impl Into<String>) -> Response<Body> {
+    Response::builder()
+        .status(code)
+        .body(Body::from(msg.into() + "\n"))
+        .unwrap()
 }

--- a/blobnet/src/utils.rs
+++ b/blobnet/src/utils.rs
@@ -5,22 +5,22 @@ use std::path::Path;
 use std::{fs, io};
 
 use anyhow::{anyhow, ensure, Result};
-use hyper::{Body, StatusCode};
+use hyper::Body;
 use tempfile::NamedTempFile;
 use tokio_stream::StreamExt;
 use tokio_util::io::{ReaderStream, StreamReader};
 
-use crate::ReadStream;
+use crate::{Error, ReadStream};
 
 fn is_hash(s: &str) -> bool {
     s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 
 /// Extracts the hash from the path component of an HTTP request URL.
-pub(crate) fn get_hash(path: &str) -> Result<&str, StatusCode> {
+pub(crate) fn get_hash(path: &str) -> Result<&str, Error> {
     match path.strip_prefix('/') {
         Some(hash) if is_hash(hash) => Ok(hash),
-        _ => Err(StatusCode::NOT_FOUND),
+        _ => Err(Error::NotFound),
     }
 }
 


### PR DESCRIPTION
Previously, it would just silently fail, which makes debugging harder.