### PR TITLE
Simplify LRU cache and fix memory leak

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,12 +434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "bimap"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0455254eb5c6964c4545d8bac815e1a1be4f3afe0ae695ea539c12d728d44b"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,10 +450,9 @@ dependencies = [
  "aws-sdk-s3",
  "aws-types",
  "base64",
- "bimap",
- "cache-advisor",
  "clap",
  "fastrand",
+ "hashlink",
  "hex",
  "hyper",
  "hyperlocal",
@@ -457,7 +461,6 @@ dependencies = [
  "quickcheck",
  "sha2",
  "shutdown",
- "slab",
  "tempfile",
  "thiserror",
  "tokio",
@@ -494,15 +497,6 @@ checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
 dependencies = [
  "bytes",
  "either",
-]
-
-[[package]]
-name = "cache-advisor"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11788ff413a0fe136b34756f5cce23a5a70fb28c18eccba75c5a6f9f7a95ad38"
-dependencies = [
- "crossbeam-queue",
 ]
 
 [[package]]
@@ -593,25 +587,6 @@ name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
 ]
@@ -788,6 +763,18 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "heck"

--- a/blobnet/Cargo.toml
+++ b/blobnet/Cargo.toml
@@ -19,10 +19,9 @@ aws-config = "0.49.0"
 aws-sdk-s3 = "0.19.0"
 aws-types = "0.49.0"
 base64 = "0.13.1"
-bimap = "0.6.2"
-cache-advisor = "1.0.12"
 clap = { version = "4.0.18", features = ["derive", "env"] }
 fastrand = "1.8.0"
+hashlink = "0.8.1"
 hex = "0.4.3"
 hyper = { version = "0.14.18", features = ["full"] }
 hyperlocal = "0.8.0"
@@ -30,7 +29,6 @@ named-retry = { path = "../named-retry", version = "0.2.0" }
 parking_lot = "0.12.1"
 sha2 = "0.10.2"
 shutdown = "0.2.1"
-slab = "0.4.7"
 tempfile = "3.3.0"
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["full"] }


### PR DESCRIPTION
I found a memory leak in the existing code and wrote a test that reproduced it.

But at this point I'm just going to remove all of this `cache-advisor` / `bimap` code right now because it's prone to memory leaks if not implemented perfectly, and I'll replace it with our own, very simple LRU cache implementation. No two-phase stuff, just extremely basic.