### PR TITLE
Write data to EFS / LocalDir in 2 MiB chunks

### DIFF
--- a/blobnet/src/utils.rs
+++ b/blobnet/src/utils.rs
@@ -1,8 +1,8 @@
 //! File system and hash utilities used by the file server.
 
-use std::io::{ErrorKind, Read};
+use std::fs;
+use std::io::{self, BufWriter, ErrorKind, Read};
 use std::path::Path;
-use std::{fs, io};
 
 use anyhow::{anyhow, ensure, Result};
 use hyper::Body;
@@ -66,7 +66,10 @@ pub(crate) fn atomic_copy(mut source: impl Read, dest: impl AsRef<Path>) -> Resu
 
         fs::create_dir_all(&parent)?;
         let mut file = NamedTempFile::new_in(parent)?;
-        std::io::copy(&mut source, &mut file)?;
+        {
+            let mut writer = BufWriter::with_capacity(1 << 21, &mut file);
+            std::io::copy(&mut source, &mut writer)?;
+        }
 
         if let Err(err) = file.persist_noclobber(dest) {
             // Ignore error if another caller created the file in the meantime.

--- a/blobnet/src/utils.rs
+++ b/blobnet/src/utils.rs
@@ -68,7 +68,7 @@ pub(crate) fn atomic_copy(mut source: impl Read, dest: impl AsRef<Path>) -> Resu
         let mut file = NamedTempFile::new_in(parent)?;
         {
             let mut writer = BufWriter::with_capacity(1 << 21, &mut file);
-            std::io::copy(&mut source, &mut writer)?;
+            io::copy(&mut source, &mut writer)?;
         }
 
         if let Err(err) = file.persist_noclobber(dest) {


### PR DESCRIPTION
In my measurements, adding a 2 MiB buffer to the `std::io::copy` call has increased write throughput of a 128 MiB file to EFS from:

- Without buffering (before): 1 MiB / s
- With buffering (after): 30 MiB / s

This change adds the buffer. Note that `std::io::write()` has a specialization specifically for BufWriter that optimizes out its second internal stack buffer, so this code is equivalent or as fast as directly writing a `for`-loop over buffered chunks.

Note: There are some messages on Slack. It's late, I'm going to discuss this tomorrow with a fresh perspective.