### PR TITLE
Add a lifetime to ReadStream for a more flexible API

### DIFF
--- a/blobnet/benches/read_benchmark.rs
+++ b/blobnet/benches/read_benchmark.rs
@@ -1,4 +1,4 @@
-use std::{io::Cursor, time::Duration};
+use std::time::Duration;
 
 use blobnet::provider::{self, Provider};
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -9,7 +9,7 @@ async fn insert_read(provider: impl Provider) -> anyhow::Result<()> {
     for i in 0..100 {
         let mut data = b"asdf".repeat(256);
         data.extend(u32::to_le_bytes(i));
-        let hash = provider.put(Box::pin(Cursor::new(data))).await?;
+        let hash = provider.put(Box::pin(&data[..])).await?;
         hashes.push(hash);
     }
     for _ in 0..100 {

--- a/blobnet/src/client.rs
+++ b/blobnet/src/client.rs
@@ -102,7 +102,11 @@ impl<C: Connect + Clone + Send + Sync + 'static> FileClient<C> {
     }
 
     /// Read a range of bytes from a file.
-    pub async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    pub async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         let make_req = || async {
             let mut req = Request::builder()
                 .method("GET")

--- a/blobnet/src/client.rs
+++ b/blobnet/src/client.rs
@@ -12,7 +12,7 @@ use crate::headers::{HEADER_FILE_LENGTH, HEADER_RANGE, HEADER_SECRET};
 #[cfg(doc)]
 use crate::provider::Remote;
 use crate::utils::body_stream;
-use crate::{Error, ReadStream};
+use crate::{BlobRange, Error, ReadStream};
 
 /// An asynchronous client for the file server.
 ///
@@ -102,11 +102,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> FileClient<C> {
     }
 
     /// Read a range of bytes from a file.
-    pub async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    pub async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         let make_req = || async {
             let mut req = Request::builder()
                 .method("GET")

--- a/blobnet/src/lib.rs
+++ b/blobnet/src/lib.rs
@@ -134,10 +134,10 @@ mod headers {
 }
 
 /// A stream of bytes from some data source.
-pub type ReadStream = Pin<Box<dyn AsyncRead + Send>>;
+pub type ReadStream<'a> = Pin<Box<dyn AsyncRead + Send + 'a>>;
 
 /// Helper function to collect a [`ReadStream`] into a byte vector.
-pub async fn read_to_vec(mut stream: ReadStream) -> io::Result<Vec<u8>> {
+pub async fn read_to_vec(mut stream: ReadStream<'_>) -> io::Result<Vec<u8>> {
     let mut buf = Vec::new();
     stream.read_to_end(&mut buf).await?;
     Ok(buf)

--- a/blobnet/src/lib.rs
+++ b/blobnet/src/lib.rs
@@ -133,6 +133,9 @@ mod headers {
     pub const HEADER_FILE_LENGTH: HeaderName = HeaderName::from_static("x-bn-file-length");
 }
 
+/// Internal type alias for a byte range.
+type BlobRange = Option<(u64, u64)>;
+
 /// A stream of bytes from some data source.
 pub type ReadStream<'a> = Pin<Box<dyn AsyncRead + Send + 'a>>;
 

--- a/blobnet/src/lib.rs
+++ b/blobnet/src/lib.rs
@@ -25,7 +25,7 @@
 //! let provider = provider::Memory::new();
 //!
 //! // Insert data, returning its hash.
-//! let data: ReadStream = Box::pin(Cursor::new(b"hello blobnet world!"));
+//! let data: ReadStream = Box::pin(b"hello blobnet world!" as &[u8]);
 //! let hash = provider.put(data).await?;
 //!
 //! // Check if a blob exists and return its size.

--- a/blobnet/src/provider.rs
+++ b/blobnet/src/provider.rs
@@ -27,7 +27,7 @@ use tokio_util::io::StreamReader;
 
 use crate::client::FileClient;
 use crate::utils::{atomic_copy, hash_path, stream_body};
-use crate::{read_to_vec, Error, ReadStream};
+use crate::{read_to_vec, BlobRange, Error, ReadStream};
 
 /// Specifies a storage backend for the blobnet service.
 ///
@@ -56,11 +56,7 @@ pub trait Provider: Send + Sync {
     /// ```ignore
     /// async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream<'static>, Error>;
     /// ```
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error>;
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error>;
 
     /// Adds a binary blob to storage, returning its hash.
     ///
@@ -96,11 +92,7 @@ impl Provider for Memory {
         Ok(bytes.len() as u64)
     }
 
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         check_range(range)?;
         let data = self.data.read();
         let mut bytes = match data.get(hash) {
@@ -170,11 +162,7 @@ impl Provider for S3 {
         }
     }
 
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         check_range(range)?;
 
         if matches!(range, Some((s, e)) if s == e) {
@@ -259,11 +247,7 @@ impl Provider for LocalDir {
         }
     }
 
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         check_range(range)?;
         let key = hash_path(hash)?;
         let path = self.dir.join(key);
@@ -312,11 +296,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> Provider for Remote<C> {
         self.client.head(hash).await
     }
 
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         self.client.get(hash, range).await
     }
 
@@ -350,7 +330,7 @@ async fn make_data_tempfile(data: ReadStream<'_>) -> anyhow::Result<(String, Fil
     Ok((hash, file))
 }
 
-fn check_range(range: Option<(u64, u64)>) -> Result<(), Error> {
+fn check_range(range: BlobRange) -> Result<(), Error> {
     match range {
         Some((start, end)) if start > end => Err(Error::BadRange),
         _ => Ok(()),
@@ -374,11 +354,7 @@ impl<P1: Provider, P2: Provider> Provider for (P1, P2) {
         }
     }
 
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         match self.0.get(hash, range).await {
             Ok(res) => Ok(res),
             Err(_) => self.1.get(hash, range).await,
@@ -583,11 +559,7 @@ impl<P: Provider + 'static> Provider for Cached<P> {
         self.state.get_cached_size(hash).await
     }
 
-    async fn get(
-        &self,
-        hash: &str,
-        range: Option<(u64, u64)>,
-    ) -> Result<ReadStream<'static>, Error> {
+    async fn get(&self, hash: &str, range: BlobRange) -> Result<ReadStream<'static>, Error> {
         let (start, end) = range.unwrap_or((0, u64::MAX));
         check_range(range)?;
 

--- a/blobnet/src/provider.rs
+++ b/blobnet/src/provider.rs
@@ -54,9 +54,13 @@ pub trait Provider: Send + Sync {
     /// Equivalent to:
     ///
     /// ```ignore
-    /// async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error>;
+    /// async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream<'static>, Error>;
     /// ```
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error>;
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error>;
 
     /// Adds a binary blob to storage, returning its hash.
     ///
@@ -66,9 +70,9 @@ pub trait Provider: Send + Sync {
     /// Equivalent to:
     ///
     /// ```ignore
-    /// async fn put(&self, data: ReadStream) -> Result<String, Error>;
+    /// async fn put(&self, data: ReadStream<'_>) -> Result<String, Error>;
     /// ```
-    async fn put(&self, data: ReadStream) -> Result<String, Error>;
+    async fn put(&self, data: ReadStream<'_>) -> Result<String, Error>;
 }
 
 /// A provider that stores blobs in memory, only used for testing.
@@ -92,7 +96,11 @@ impl Provider for Memory {
         Ok(bytes.len() as u64)
     }
 
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         check_range(range)?;
         let data = self.data.read();
         let mut bytes = match data.get(hash) {
@@ -108,7 +116,7 @@ impl Provider for Memory {
         Ok(Box::pin(Cursor::new(bytes)))
     }
 
-    async fn put(&self, mut data: ReadStream) -> Result<String, Error> {
+    async fn put(&self, mut data: ReadStream<'_>) -> Result<String, Error> {
         let mut buf = Vec::new();
         data.read_to_end(&mut buf).await?;
         let hash = format!("{:x}", Sha256::new().chain_update(&buf).finalize());
@@ -162,7 +170,11 @@ impl Provider for S3 {
         }
     }
 
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         check_range(range)?;
 
         if matches!(range, Some((s, e)) if s == e) {
@@ -199,7 +211,7 @@ impl Provider for S3 {
         }
     }
 
-    async fn put(&self, data: ReadStream) -> Result<String, Error> {
+    async fn put(&self, data: ReadStream<'_>) -> Result<String, Error> {
         let (hash, file) = make_data_tempfile(data).await?;
         let body = ByteStream::read_from()
             .file(file)
@@ -247,7 +259,11 @@ impl Provider for LocalDir {
         }
     }
 
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         check_range(range)?;
         let key = hash_path(hash)?;
         let path = self.dir.join(key);
@@ -266,7 +282,7 @@ impl Provider for LocalDir {
         }
     }
 
-    async fn put(&self, data: ReadStream) -> Result<String, Error> {
+    async fn put(&self, data: ReadStream<'_>) -> Result<String, Error> {
         let (hash, file) = make_data_tempfile(data).await?;
         let file = file.into_std().await;
         let key = hash_path(&hash)?;
@@ -296,11 +312,15 @@ impl<C: Connect + Clone + Send + Sync + 'static> Provider for Remote<C> {
         self.client.head(hash).await
     }
 
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         self.client.get(hash, range).await
     }
 
-    async fn put(&self, data: ReadStream) -> Result<String, Error> {
+    async fn put(&self, data: ReadStream<'_>) -> Result<String, Error> {
         let (_, file) = make_data_tempfile(data).await?;
         self.client
             .put(|| async { Ok(stream_body(Box::pin(file.try_clone().await?))) })
@@ -309,7 +329,7 @@ impl<C: Connect + Clone + Send + Sync + 'static> Provider for Remote<C> {
 }
 
 /// Stream data from a source into a temporary file and compute the hash.
-async fn make_data_tempfile(data: ReadStream) -> anyhow::Result<(String, File)> {
+async fn make_data_tempfile(data: ReadStream<'_>) -> anyhow::Result<(String, File)> {
     let mut file = File::from_std(task::spawn_blocking(tempfile).await??);
     let mut hash = Sha256::new();
     let mut reader = BufReader::new(data);
@@ -337,8 +357,8 @@ fn check_range(range: Option<(u64, u64)>) -> Result<(), Error> {
     }
 }
 
-fn empty_stream() -> ReadStream {
-    Box::pin(Cursor::new(Bytes::new()))
+fn empty_stream() -> ReadStream<'static> {
+    Box::pin(b"" as &[u8])
 }
 
 // A pair of providers is also a provider, acting as a fallback.
@@ -354,14 +374,18 @@ impl<P1: Provider, P2: Provider> Provider for (P1, P2) {
         }
     }
 
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         match self.0.get(hash, range).await {
             Ok(res) => Ok(res),
             Err(_) => self.1.get(hash, range).await,
         }
     }
 
-    async fn put(&self, data: ReadStream) -> Result<String, Error> {
+    async fn put(&self, data: ReadStream<'_>) -> Result<String, Error> {
         self.0.put(data).await
     }
 }
@@ -559,7 +583,11 @@ impl<P: Provider + 'static> Provider for Cached<P> {
         self.state.get_cached_size(hash).await
     }
 
-    async fn get(&self, hash: &str, range: Option<(u64, u64)>) -> Result<ReadStream, Error> {
+    async fn get(
+        &self,
+        hash: &str,
+        range: Option<(u64, u64)>,
+    ) -> Result<ReadStream<'static>, Error> {
         let (start, end) = range.unwrap_or((0, u64::MAX));
         check_range(range)?;
 
@@ -623,7 +651,7 @@ impl<P: Provider + 'static> Provider for Cached<P> {
         Ok(Box::pin(StreamReader::new(stream)))
     }
 
-    async fn put(&self, data: ReadStream) -> Result<String, Error> {
+    async fn put(&self, data: ReadStream<'_>) -> Result<String, Error> {
         self.state.inner.put(data).await
     }
 }

--- a/blobnet/src/server.rs
+++ b/blobnet/src/server.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use crate::headers::{HEADER_FILE_LENGTH, HEADER_RANGE, HEADER_SECRET};
 use crate::provider::Provider;
 use crate::utils::{body_stream, get_hash, stream_body};
-use crate::{make_resp, Error};
+use crate::{make_resp, BlobRange, Error};
 
 /// Configuration for the file server.
 pub struct Config {
@@ -105,7 +105,7 @@ async fn handle(config: Arc<Config>, req: Request<Body>) -> Result<Response<Body
 ///
 /// The start index is inclusive, and the end index is exclusive. This differs
 /// from the standard HTTP `Range` header, which has both ends inclusive.
-fn parse_range_header(s: &HeaderValue) -> Option<(u64, u64)> {
+fn parse_range_header(s: &HeaderValue) -> BlobRange {
     let s = s.to_str().ok()?;
     let (start, end) = s.split_once('-')?;
     Some((start.parse().ok()?, end.parse().ok()?))

--- a/blobnet/src/utils.rs
+++ b/blobnet/src/utils.rs
@@ -86,12 +86,12 @@ pub(crate) fn atomic_copy(mut source: impl Read, dest: impl AsRef<Path>) -> Resu
 }
 
 /// Convert a [`ReadStream`] object into an HTTP body.
-pub(crate) fn stream_body(stream: ReadStream) -> Body {
+pub(crate) fn stream_body(stream: ReadStream<'static>) -> Body {
     Body::wrap_stream(ReaderStream::new(stream))
 }
 
 /// Convert an HTTP body into a [`ReadStream`] object.
-pub(crate) fn body_stream(body: Body) -> ReadStream {
+pub(crate) fn body_stream(body: Body) -> ReadStream<'static> {
     Box::pin(StreamReader::new(StreamExt::map(body, |result| {
         result.map_err(|err| io::Error::new(io::ErrorKind::Other, err))
     })))

--- a/blobnet/tests/files_test.rs
+++ b/blobnet/tests/files_test.rs
@@ -27,7 +27,7 @@ async fn spawn_temp_server() -> Result<String> {
     Ok(format!("http://{addr}"))
 }
 
-async fn eat(mut stream: ReadStream) -> Result<String> {
+async fn eat(mut stream: ReadStream<'static>) -> Result<String> {
     let mut buf = String::new();
     stream.read_to_string(&mut buf).await?;
     Ok(buf)

--- a/blobnet/tests/prop_test.rs
+++ b/blobnet/tests/prop_test.rs
@@ -1,6 +1,6 @@
 //! Property-based consistency tests for blobnet.
 
-use std::{io::Cursor, path::Path};
+use std::path::Path;
 
 use blobnet::{
     provider::{Cached, LocalDir, Memory, Provider},
@@ -36,12 +36,10 @@ async fn run_cached_comparison(
     let mem_cached = Cached::new(Memory::new(), dir.join("c1"), 4096);
     let ldir_cached = Cached::new(LocalDir::new(dir.join("ldir2")), dir.join("c2"), 4096);
 
-    let cursor = || Box::pin(Cursor::new(data.clone()));
-
-    let h1 = mem.put(cursor()).await?;
-    let h2 = ldir.put(cursor()).await?;
-    let h3 = mem_cached.put(cursor()).await?;
-    let h4 = ldir_cached.put(cursor()).await?;
+    let h1 = mem.put(Box::pin(&data[..])).await?;
+    let h2 = ldir.put(Box::pin(&data[..])).await?;
+    let h3 = mem_cached.put(Box::pin(&data[..])).await?;
+    let h4 = ldir_cached.put(Box::pin(&data[..])).await?;
 
     Ok(h1 == h2 && h1 == h3 && h1 == h4 && {
         let r1 = mem.get(&h1, range).await;


### PR DESCRIPTION
This changes the ReadStream type definition from

```rust
pub type ReadStream = Pin<Box<dyn AsyncRead + Send>>;
```

to

```rust
pub type ReadStream<'a> = Pin<Box<dyn AsyncRead + Send + 'a>>;
```

By adding this lifetime, the code does become a little bit more complicated since lifetimes need to be propagated, but we can simplify some use of `blobnet.put()` as a result. Now to put a `data: &[u8]` we can just do:

```rust
blobnet.put(Box::pin(data)).await?;
```

Instead of the previous:

```rust
use std::io::Cursor;
blobnet.put(Box::pin(Cursor::new(data.to_owned()))).await?;
```

This avoids an unnecessary memory copy. The reason why this was necessary in the past is because `ReadStream` previously just always took a `'static` lifetime implicitly, but for these arguments it's sometimes useful to have a stream that's borrowed rather than owned.

cc @freider who pointed this out